### PR TITLE
excluded options->qty from generateHash()

### DIFF
--- a/src/CartItem.php
+++ b/src/CartItem.php
@@ -68,6 +68,8 @@ class CartItem
             $cartItemArray = (array)$this;
 
             unset($cartItemArray['options']['qty']);
+            
+            ksort($cartItemArray['options']);
 
             $this->itemHash = app(LaraCart::HASH, $cartItemArray);
         } elseif ($force || empty($this->itemHash) === true) {

--- a/src/CartItem.php
+++ b/src/CartItem.php
@@ -67,7 +67,7 @@ class CartItem
 
             $cartItemArray = (array)$this;
 
-            ksort($cartItemArray['options']);
+            unset($cartItemArray['options']['qty']);
 
             $this->itemHash = app(LaraCart::HASH, $cartItemArray);
         } elseif ($force || empty($this->itemHash) === true) {


### PR DESCRIPTION
excluded options->qty from generateHash() to prevent invalid hash if the options->qty is changed.

other option changes like color etc. need to get a new Hash.