### PR TITLE
excluded options->qty from generateHash()

### DIFF
--- a/src/CartItem.php
+++ b/src/CartItem.php
@@ -66,7 +66,9 @@ class CartItem
             $this->itemHash = null;
 
             $cartItemArray = (array)$this;
-
+            
+            unset($cartItemArray['options']['qty']);
+            
             ksort($cartItemArray['options']);
 
             $this->itemHash = app(LaraCart::HASH, $cartItemArray);


### PR DESCRIPTION
added unset for options->qty

left alone ksort($cartItemArray['options']);