### PR TITLE
Return item not itemhash when item is removed.

### DIFF
--- a/src/LaraCart.php
+++ b/src/LaraCart.php
@@ -381,7 +381,7 @@ class LaraCart implements LaraCartContract
             }
         }
 
-        $this->events->fire('laracart.removeItem', $itemHash);
+        $this->events->fire('laracart.removeItem', $item);
 
         $this->update();
     }


### PR DESCRIPTION
When an item is removed from the cart, return the

full item object instead of just the itemhash. The

reasoning for this is that the itemhash is still

accessible from the item object, but not the other

way around (you can't use the itemhash to retrieve

any info about the removed item once it's removed

from the cart.