### PR TITLE
adding another test case for coupons

### DIFF
--- a/src/LaraCart.php
+++ b/src/LaraCart.php
@@ -562,8 +562,9 @@ class LaraCart implements LaraCartContract
                 } else {
                     $itemPrice = $item->subTotal(false);
 
-                    if (($discounted + $itemPrice) > $totalDiscount && config('laracart.discountTaxable', true)) {
-                        $totalTax += $item->tax($totalDiscount - $discounted);
+                    if (($discounted + $itemPrice) > $totalDiscount) {
+                        $totalTax += config('laracart.discountTaxable', true) ?
+                            $item->tax($totalDiscount - $discounted) : $item->tax();
                     }
 
                     $discounted += $itemPrice;

--- a/src/LaraCart.php
+++ b/src/LaraCart.php
@@ -562,7 +562,7 @@ class LaraCart implements LaraCartContract
                 } else {
                     $itemPrice = $item->subTotal(false);
 
-                    if (($discounted + $itemPrice) > $totalDiscount) {
+                    if (($discounted + $itemPrice) > $totalDiscount && config('laracart.discountTaxable', true)) {
                         $totalTax += $item->tax($totalDiscount - $discounted);
                     }
 

--- a/tests/CouponsTest.php
+++ b/tests/CouponsTest.php
@@ -251,6 +251,29 @@ class CouponsTest extends Orchestra\Testbench\TestCase
     }
 
     /**
+     * Test cart percentage coupon when items are taxable
+     */
+    public function testCouponsTaxableItem()
+    {
+        $this->addItem(1, 1);
+
+        $percentCoupon = new LukePOLO\LaraCart\Coupons\Percentage('20%OFF', '.2');
+
+        $this->laracart->addCoupon($percentCoupon);
+
+        $this->assertEquals($percentCoupon, $this->laracart->findCoupon('20%OFF'));
+
+        $this->assertEquals('20%', $percentCoupon->displayValue());
+        $this->assertEquals('0.20', $percentCoupon->discount());
+
+        $this->app['config']->set('laracart.discountTaxable', false);
+
+        $this->assertEquals('0.07', $this->laracart->taxTotal(false));
+
+        $this->assertEquals('0.87', $this->laracart->total(false));
+    }
+
+    /**
      * Test if we can remove all coupons from the cart.
      */
     public function testRemoveCoupons()

--- a/tests/CouponsTest.php
+++ b/tests/CouponsTest.php
@@ -228,6 +228,29 @@ class CouponsTest extends Orchestra\Testbench\TestCase
     }
 
     /**
+     * Test cart percentage coupon when items are not taxable
+     */
+    public function testCouponsNotTaxableItem()
+    {
+        $this->addItem(1, 1, false);
+
+        $percentCoupon = new LukePOLO\LaraCart\Coupons\Percentage('20%OFF', '.2');
+
+        $this->laracart->addCoupon($percentCoupon);
+
+        $this->assertEquals($percentCoupon, $this->laracart->findCoupon('20%OFF'));
+
+        $this->assertEquals('20%', $percentCoupon->displayValue());
+        $this->assertEquals('0.20', $percentCoupon->discount());
+
+        $this->app['config']->set('laracart.discountTaxable', false);
+
+        $this->assertEquals(0, $this->laracart->taxTotal(false));
+
+        $this->assertEquals('0.80', $this->laracart->total(false));
+    }
+
+    /**
      * Test if we can remove all coupons from the cart.
      */
     public function testRemoveCoupons()


### PR DESCRIPTION
Add non taxable items to the cart. After setting the discountTaxable to false, if I add a cart coupon the tax calculation is off.