### PR TITLE
Fix coupon times validator

### DIFF
--- a/src/Traits/CouponTrait.php
+++ b/src/Traits/CouponTrait.php
@@ -142,7 +142,7 @@ trait CouponTrait
      */
     public function checkValidTimes(Carbon $startDate, Carbon $endDate, $throwErrors = true)
     {
-        if (Carbon::now()->between($startDate, $endDate, true)) {
+        if (Carbon::now()->between($startDate, $endDate, false)) {
             return true;
         } else {
             if ($throwErrors) {

--- a/src/Traits/CouponTrait.php
+++ b/src/Traits/CouponTrait.php
@@ -142,7 +142,7 @@ trait CouponTrait
      */
     public function checkValidTimes(Carbon $startDate, Carbon $endDate, $throwErrors = true)
     {
-        if (Carbon::now()->between($startDate, $endDate)) {
+        if (Carbon::now()->between($startDate, $endDate, true)) {
             return true;
         } else {
             if ($throwErrors) {


### PR DESCRIPTION
When $startDate is empty or NULL and $endDate is less then current time it should return an exception.