### PR TITLE
always get subtotal without discount, else it will be double calculated

### DIFF
--- a/src/LaraCart.php
+++ b/src/LaraCart.php
@@ -606,7 +606,7 @@ class LaraCart implements LaraCartContract
      */
     public function total($format = true, $withDiscount = true, $withTax = true, $withFees = true)
     {
-        $total = $this->subTotal(false);
+        $total = $this->subTotal(false, false);
 
         if ($withFees) {
             $total += $this->feeTotals(false);


### PR DESCRIPTION
When having a coupon active the total() function will double calculate the discount.