### PR TITLE
Cast items to array.

### DIFF
--- a/src/LaraCart.php
+++ b/src/LaraCart.php
@@ -747,7 +747,7 @@ class LaraCart implements LaraCartContract
 
         if ($withItemDiscounts) {
             /** @var CartItem $item */
-            foreach ($this->cart->items as $item) {
+            foreach ((array) $this->cart->items as $item) {
                 $total += floatval($item->getDiscount(false));
             }
         }


### PR DESCRIPTION
Fix issues when items are null and php raises "Invalid argument supplied for foreach()".

Error trace:
```
{message: "Invalid argument supplied for foreach()", exception: "ErrorException",…}
exception
:
"ErrorException"
file
:
"/www/cart/vendor/lukepolo/laracart/src/LaraCart.php"
line
:
750
message
:
"Invalid argument supplied for foreach()"
```