### PR TITLE
Add pricing in cents option to the config file with the relevant code

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 /vendor
 composer.lock
+/.idea

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,2 @@
 /vendor
 composer.lock
-/.idea

--- a/src/CartItem.php
+++ b/src/CartItem.php
@@ -59,7 +59,7 @@ class CartItem
         $this->name = $name;
         $this->taxable = $taxable;
         $this->lineItem = $lineItem;
-        $this->price = floatval($price);
+        $this->price = (config('laracart.prices_in_cents', false) === true ? intval($price) : floatval($price));
         $this->tax = config('laracart.tax');
         $this->itemModel = config('laracart.item_model', null);
         $this->itemModelRelations = config('laracart.item_model_relations', []);

--- a/src/LaraCart.php
+++ b/src/LaraCart.php
@@ -716,7 +716,15 @@ class LaraCart implements LaraCartContract
      */
     public static function formatMoney($number, $locale = null, $internationalFormat = false, $format = true)
     {
-        $number = number_format($number, 2, '.', '');
+    	// When prices in cents needs to be formatted, divide by 100 to allow formatting in whole units
+		if(config('laracart.prices_in_cents', false) === true && $format){
+			$number = $number / 100;
+			// When prices in cents do not need to be formatted then cast to integer and round the price
+		} elseif(config('laracart.prices_in_cents', false) === true && !$format) {
+			$number = (int) round($number);
+		} else {
+		    $number = number_format($number, 2, '.', '');
+	    }
 
         if ($format) {
             setlocale(LC_MONETARY, null);

--- a/src/config/laracart.php
+++ b/src/config/laracart.php
@@ -40,6 +40,19 @@ return [
     */
     'international_format' => false,
 
+	/*
+    |--------------------------------------------------------------------------
+    | If true, lets you supply and retrieve all prices in cents.
+	| To retrieve the prices as integer in cents, set the $format parameter
+	| to false for the various price functions. Otherwise you will retrieve
+	| the formatted price instead.
+	| Make sure when adding products to the cart, adding coupons, etc, to
+	| supply the price in cents too.
+    |--------------------------------------------------------------------------
+    |
+    */
+	'prices_in_cents' => false,
+
     /*
     |--------------------------------------------------------------------------
     | Sets the tax for the cart and items, you can change per item

--- a/tests/ItemsTest.php
+++ b/tests/ItemsTest.php
@@ -164,6 +164,24 @@ class ItemsTest extends Orchestra\Testbench\TestCase
         $this->assertEquals(32.1, $item->subTotal(false, true, false, true)); // return subtotal with tax
     }
 
+	/**
+	 * Test the prices in cents based on the item.
+	 */
+	public function testItemPriceInCents()
+	{
+		$this->app['config']->set('laracart.prices_in_cents', true);
+		$item = $this->addItem(3, 1000);
+
+		$this->assertEquals(1000, $item->price(false));
+		$this->assertEquals(1070, $item->price(false, false, true)); // return item price with tax
+		$this->assertEquals(3000, $item->subTotal(false));
+		$this->assertEquals(3210, $item->subTotal(false, true, false, true)); // return subtotal with tax
+
+		// Test that floats are converted to int and not rounded in the constructor
+		$item2 = $this->addItem(3, 1000.55);
+		$this->assertEquals(1000, $item2->price(false));
+	}
+
     /**
      * Test removing an item from the cart.
      */

--- a/tests/LaraCartTest.php
+++ b/tests/LaraCartTest.php
@@ -60,6 +60,24 @@ class LaraCartTest extends Orchestra\Testbench\TestCase
         $this->assertEquals('$25.54', $this->laracart->formatMoney('25.544'));
     }
 
+	/**
+	 * Testing the money format function with the prices_in_cents config setting.
+	 */
+	public function testFormatMoneyPricesInCents()
+	{
+		$this->app['config']->set('laracart.prices_in_cents', true);
+
+		$this->assertEquals('$25.00', $this->laracart->formatMoney(2500));
+		$this->assertEquals('USD 25.00', $this->laracart->formatMoney(2500, null, true));
+		$this->assertEquals(2500, $this->laracart->formatMoney(2500, null, null, false));
+
+		$this->assertEquals('$25.01', $this->laracart->formatMoney(2500.55));
+		$this->assertEquals('$25.00', $this->laracart->formatMoney(2500.44));
+
+		$this->assertEquals(2501, $this->laracart->formatMoney(2500.55, null, null, false));
+		$this->assertEquals(2500, $this->laracart->formatMoney(2500.44,null, null, false));
+	}
+
     /**
      * Test getting the attributes from the cart.
      */

--- a/tests/TotalsTest.php
+++ b/tests/TotalsTest.php
@@ -26,16 +26,48 @@ class TotalsTest extends Orchestra\Testbench\TestCase
         $this->assertEquals(0, $this->laracart->total(false));
     }
 
+	/**
+	 * Test total discounts when using the pricing_in_cents config setting.
+	 */
+	public function testTotalDiscountInCents()
+	{
+		$this->app['config']->set('laracart.prices_in_cents', true);
+		$this->addItem(1, 1000);
+
+		$fixedCoupon = new LukePOLO\LaraCart\Coupons\Fixed(
+			'10OFF', 1000
+		);
+
+		$this->laracart->addCoupon($fixedCoupon);
+
+		$this->assertEquals('$10.00', $this->laracart->totalDiscount());
+		$this->assertEquals(1000, $this->laracart->totalDiscount(false));
+
+		$this->assertEquals(0, $this->laracart->total(false));
+	}
+
     /**
-     * test total taxes.
+     * Test total taxes.
      */
     public function testTaxTotal()
     {
-        $this->addItem();
+	    $this->addItem();
 
         $this->assertEquals('$0.07', $this->laracart->taxTotal());
         $this->assertEquals('0.07', $this->laracart->taxTotal(false));
     }
+
+	/**
+	 * Test total taxes when using the pricing_in_cents config setting.
+	 */
+	public function testTaxTotalInCents()
+	{
+		$this->app['config']->set('laracart.prices_in_cents', true);
+		$this->addItem(1, 100);
+
+		$this->assertEquals('$0.07', $this->laracart->taxTotal());
+		$this->assertEquals(7, $this->laracart->taxTotal(false));
+	}
 
     /**
      * Test getting all the fees.
@@ -74,6 +106,18 @@ class TotalsTest extends Orchestra\Testbench\TestCase
         $this->assertEquals('$1.07', $this->laracart->total());
         $this->assertEquals('1.07', $this->laracart->total(false));
     }
+
+	/**
+	 * Test getting the final total (with tax) when using the pricing_in_cents config setting.
+	 */
+	public function testTotalInCents()
+	{
+		$this->app['config']->set('laracart.prices_in_cents', true);
+		$this->addItem(1, 100);
+
+		$this->assertEquals('$1.07', $this->laracart->total());
+		$this->assertEquals(107, $this->laracart->total(false));
+	}
 
     /**
      * Test the taxable fees total.


### PR DESCRIPTION
This commit has the following features:
- New `prices_in_cents` config setting.
- The normal formatting of `LaraCart::formatMoney` keeps working, only if `$format = false` is specified the cents are returned when `prices_in_cents` is set to true.
- For all price retrieve functions it applies that you have to specify the `$format` parameter to `false` if you want the price in cents back as an integer. Otherwise you get the formatted price string version back.