### PR TITLE
Configurable exclude options from generateHash()

### DIFF
--- a/src/CartItem.php
+++ b/src/CartItem.php
@@ -33,6 +33,7 @@ class CartItem
     protected $itemHash;
     protected $itemModel;
     protected $itemModelRelations;
+    protected $exclude_from_hash;
 
     public $locale;
     public $lineItem;
@@ -64,6 +65,7 @@ class CartItem
         $this->tax = config('laracart.tax');
         $this->itemModel = config('laracart.item_model', null);
         $this->itemModelRelations = config('laracart.item_model_relations', []);
+        $this->exclude_from_hash = config('laracart.exclude_from_hash', []);
 
         foreach ($options as $option => $value) {
             $this->$option = $value;
@@ -85,6 +87,10 @@ class CartItem
             $cartItemArray = (array) $this;
 
             unset($cartItemArray['options']['qty']);
+
+            foreach ($this->exclude_from_hash as $option) {
+                unset($cartItemArray['options'][$option]);
+            }
 
             ksort($cartItemArray['options']);
 

--- a/src/config/laracart.php
+++ b/src/config/laracart.php
@@ -190,4 +190,12 @@ return [
     |
     */
     'guard' => null,
+
+    /*
+    |--------------------------------------------------------------------------
+    | This allows you to exclude any option from generating CartItem hash
+    |--------------------------------------------------------------------------
+    |
+    */
+    'exclude_from_hash' => [],
 ];

--- a/tests/LaraCartTest.php
+++ b/tests/LaraCartTest.php
@@ -191,6 +191,23 @@ class LaraCartTest extends Orchestra\Testbench\TestCase
         $this->assertNotEquals($prevHash, $item->getHash());
     }
 
+
+    /**
+     * Tests if generating a same hash when we change an excluded option.
+     */
+    public function testGeneratingHashesExistConfig()
+    {
+        $this->app['config']->set('laracart.exclude_from_hash', ['some_option']);
+
+        $item = $this->addItem(1, 1, true, ['some_option' => 'some value']);
+
+        $prevHash = $item->getHash();
+
+        $item->some_option = 'NEW VALUE';
+
+        $this->assertEquals($prevHash, $item->getHash());
+    }
+
     /**
      * Tests the facade.
      */


### PR DESCRIPTION
In config, You can exclude options from **GenerateHash()** in **CartItem**