### PR TITLE
Fix CartItem hash regeneration on quantity updates

### DIFF
--- a/src/CartItem.php
+++ b/src/CartItem.php
@@ -91,8 +91,16 @@ class CartItem
 
             $cartItemArray = (array) clone $this;
 
+            // Exclude private and protected properties. https://www.php.net/manual/en/language.types.array.php#language.types.array.casting
+            foreach ($cartItemArray as $key => $value) {
+                if ($key[0] === "\0") {
+                    unset($cartItemArray[$key]);
+                }
+            }
+
             unset($cartItemArray['discounted']);
             unset($cartItemArray['options']['qty']);
+            unset($cartItemArray['options']['model']);
 
             foreach ($this->excludeFromHash as $option) {
                 unset($cartItemArray['options'][$option]);


### PR DESCRIPTION
## Problem
Cart item hashes regenerate unexpectedly during quantity updates via `LaraCart::updateItem()`, causing cart functionality to break.

## Root Cause
The `generateHash()` method includes private/protected properties and the 'model' option in hash calculation, which can change between operations.

## Solution
- Exclude private/protected properties from hash calculation (they have null-byte prefixes when object is cast to array)
- Exclude 'model' option from hash to prevent changes when models are associated

## Changes
```php
// Exclude private and protected properties
foreach ($cartItemArray as $key => $value) {
    if ($key[0] === "\0") {
        unset($cartItemArray[$key]);
    }
}

// Exclude model option
unset($cartItemArray['options']['model']);
```

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author